### PR TITLE
Fixing class path build issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,69 +1,79 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <parent>
-    <artifactId>mojo-parent</artifactId>
-    <groupId>org.codehaus.mojo</groupId>
-    <version>22</version>
-  </parent>
-  <modelVersion>4.0.0</modelVersion>
-  <artifactId>ideauidesigner-maven-plugin</artifactId>
-  <packaging>maven-plugin</packaging>
-  <version>1.0-beta-2-SNAPSHOT</version>
-  <name>Maven IDEA UI Designer Plugin</name>
-  <description>A plugin that wraps around Intellij ant tasks to build your GUI forms into your builds (http://www.jetbrains.com/idea/features/gui_builder.html#link16)</description>
-  <inceptionYear>2006</inceptionYear>
-  <url>http://mojo.codehaus.org/ideauidesigner-maven-plugin</url>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>mojo-parent</artifactId>
+        <groupId>org.codehaus.mojo</groupId>
+        <version>22</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>ideauidesigner-maven-plugin</artifactId>
+    <packaging>maven-plugin</packaging>
+    <version>1.0-beta-2-SNAPSHOT</version>
+    <name>Maven IDEA UI Designer Plugin</name>
+    <description>A plugin that wraps around Intellij ant tasks to build your GUI forms into your builds
+        (http://www.jetbrains.com/idea/features/gui_builder.html#link16)
+    </description>
+    <inceptionYear>2006</inceptionYear>
+    <url>http://mojo.codehaus.org/ideauidesigner-maven-plugin</url>
 
-  <prerequisites>
-    <maven>2.0.4</maven>
-  </prerequisites>
+    <prerequisites>
+        <maven>2.0.4</maven>
+    </prerequisites>
 
-  <scm>
-    <connection>scm:svn:https://svn.codehaus.org/mojo/trunk/mojo/ideauidesigner-maven-plugin</connection>
-    <developerConnection>scm:svn:https://svn.codehaus.org/mojo/trunk/mojo/ideauidesigner-maven-plugin</developerConnection>
-    <url>http://fisheye.codehaus.org/browse/mojo/trunk/mojo/ideauidesigner-maven-plugin</url>
-  </scm>
+    <scm>
+        <connection>scm:svn:https://svn.codehaus.org/mojo/trunk/mojo/ideauidesigner-maven-plugin</connection>
+        <developerConnection>scm:svn:https://svn.codehaus.org/mojo/trunk/mojo/ideauidesigner-maven-plugin
+        </developerConnection>
+        <url>http://fisheye.codehaus.org/browse/mojo/trunk/mojo/ideauidesigner-maven-plugin</url>
+    </scm>
 
-  <licenses>
-    <license>
-      <name>Apache License 2</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-      <distribution>repo</distribution>
-    </license>
-  </licenses>
+    <licenses>
+        <license>
+            <name>Apache License 2</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
 
-  <developers>
-    <developer>
-      <name>Jerome Lacoste</name>
-      <email>jerome@coffeebreaks.org</email>
-      <organization>CoffeeBreaks</organization>
-      <organizationUrl>http://www.coffeebreaks.org</organizationUrl>
-      <timezone>+1</timezone>
-      <roles>
-        <role>Java Developer</role>
-      </roles>
-    </developer>
-  </developers>
+    <developers>
+        <developer>
+            <name>Jerome Lacoste</name>
+            <email>jerome@coffeebreaks.org</email>
+            <organization>CoffeeBreaks</organization>
+            <organizationUrl>http://www.coffeebreaks.org</organizationUrl>
+            <timezone>+1</timezone>
+            <roles>
+                <role>Java Developer</role>
+            </roles>
+        </developer>
+    </developers>
 
-  <dependencies>
-    <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-project</artifactId>
-      <version>2.0.1</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-plugin-api</artifactId>
-    </dependency>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-core</artifactId>
+            <version>3.0.5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-project</artifactId>
+            <version>3.0-alpha-2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-plugin-api</artifactId>
+            <version>3.0</version>
+        </dependency>
 
-    <dependency>
-      <groupId>com.intellij</groupId>
-      <artifactId>javac2</artifactId>
-      <version>7.0.3</version>
-    </dependency>
-    <dependency>
-      <groupId>com.intellij</groupId>
-      <artifactId>forms_rt</artifactId>
-      <version>7.0.3</version>
-    </dependency>
-  </dependencies>
+        <dependency>
+            <groupId>com.intellij</groupId>
+            <artifactId>javac2</artifactId>
+            <version>7.0.3</version>
+        </dependency>
+        <dependency>
+            <groupId>com.intellij</groupId>
+            <artifactId>forms_rt</artifactId>
+            <version>7.0.3</version>
+        </dependency>
+    </dependencies>
 </project>

--- a/src/main/java/org/codehaus/mojo/ideauidesigner/Javac2Mojo.java
+++ b/src/main/java/org/codehaus/mojo/ideauidesigner/Javac2Mojo.java
@@ -16,21 +16,20 @@ package org.codehaus.mojo.ideauidesigner;
  * limitations under the License.
  */
 
+import com.intellij.uiDesigner.ant.Javac2;
+import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.project.MavenProject;
-import org.apache.maven.artifact.Artifact;
-import org.apache.tools.ant.BuildException;
-import org.apache.tools.ant.Project;
-import org.apache.tools.ant.BuildListener;
 import org.apache.tools.ant.BuildEvent;
+import org.apache.tools.ant.BuildException;
+import org.apache.tools.ant.BuildListener;
+import org.apache.tools.ant.Project;
 import org.apache.tools.ant.types.Path;
 
-import com.intellij.uiDesigner.ant.Javac2;
-
 import java.io.File;
-import java.util.Iterator;
 import java.util.Collection;
+import java.util.Iterator;
 
 /**
  * Generates the Java sources from the *.form files.
@@ -46,8 +45,7 @@ import java.util.Collection;
  * @see <a href="http://www.intellij.org/twiki/bin/view/Main/IntelliJUIDesignerFAQ">ui designer Ant tasks documentation</a>.
  */
 public class Javac2Mojo
-    extends AbstractMojo
-{
+        extends AbstractMojo {
     // FIXME: it might be better to try to reuse the AbstractCompilerMojo ??
     // for now we limit the interface to the bare minimum
 
@@ -121,11 +119,10 @@ public class Javac2Mojo
     private boolean verbose;
 
     public void execute()
-        throws MojoExecutionException
-    {
+            throws MojoExecutionException {
 
-        if ( ! destDirectory.exists() && ! destDirectory.mkdirs() ) {
-           getLog().warn( "the destination directory doesn't exists and couldn't be created. The goal with probably fail." );
+        if (!destDirectory.exists() && !destDirectory.mkdirs()) {
+            getLog().warn("the destination directory doesn't exists and couldn't be created. The goal with probably fail.");
         }
 
         final Project antProject = new Project();
@@ -134,82 +131,86 @@ public class Javac2Mojo
 
         final Javac2 task = new Javac2();
 
-        task.setProject( antProject );
+        task.setProject(antProject);
 
-        task.setDestdir( destDirectory );
+        task.setDestdir(destDirectory);
 
-        task.setFailonerror( failOnError );
+        task.setFailonerror(failOnError);
 
-        final Path classpath = new Path( antProject );
+        final Path classpath = new Path(antProject);
 
-        final Collection artifacts = project.getArtifacts();
 
-        for (Iterator iterator = artifacts.iterator(); iterator.hasNext();) {
+        final Collection artifacts = project.getDependencyArtifacts();
+
+        for (Iterator iterator = artifacts.iterator(); iterator.hasNext(); ) {
             final Artifact artifact = (Artifact) iterator.next();
-            if ( ! "jar".equals( artifact.getType() ) )
-              continue;
 
-            classpath.createPathElement().setLocation( artifact.getFile() );
+            getLog().debug("candidate artifact to classpath:" + artifact);
+
+            if (!"jar".equals(artifact.getType()) || Artifact.SCOPE_TEST.equals( artifact.getScope() ) )
+                continue;
+
+            getLog().debug("collected artifact as classpath element:" + artifact);
+
+            classpath.createPathElement().setLocation(artifact.getFile());
         }
 
-        classpath.createPathElement().setLocation( destDirectory );
 
-        getLog().debug( "created classpath:" + classpath );
+        classpath.createPathElement().setLocation(destDirectory);
 
-        task.setClasspath( classpath );
+        getLog().debug("created classpath:" + classpath);
 
-        task.setFork( fork );
+        task.setClasspath(classpath);
+
+        task.setFork(fork);
 
         // task.setMemoryInitialSize();
 
         // task.setMemoryMaximumSize()
 
-        task.setDebug( debug );
+        task.setDebug(debug);
 
-        task.setVerbose( verbose );
+        task.setVerbose(verbose);
 
-        task.setSrcdir( new Path( antProject, sourceDirectory.getAbsolutePath() ) );
+        task.setSrcdir(new Path(antProject, sourceDirectory.getAbsolutePath()));
 
-        task.setIncludes( "**/*.form" );
+        task.setIncludes("**/*.form");
 
-        getLog().info( "Executing IDEA UI Designer task..." );
+        getLog().info("Executing IDEA UI Designer task...");
 
-        try
-        {
+        try {
             task.execute();
-        }
-        catch ( BuildException e )
-        {
-            throw new MojoExecutionException( "command execution failed", e );
+        } catch (BuildException e) {
+            throw new MojoExecutionException("command execution failed", e);
         }
     }
 
     private class DebugAntBuildListener implements BuildListener {
-        public void buildStarted( final BuildEvent buildEvent ) {
+        public void buildStarted(final BuildEvent buildEvent) {
             getLog().debug(buildEvent.getMessage());
         }
 
-        public void buildFinished( final BuildEvent buildEvent ) {
+        public void buildFinished(final BuildEvent buildEvent) {
             getLog().debug(buildEvent.getMessage());
         }
 
-        public void targetStarted( final BuildEvent buildEvent ) {
+        public void targetStarted(final BuildEvent buildEvent) {
             getLog().debug(buildEvent.getMessage());
         }
 
-        public void targetFinished( final BuildEvent buildEvent ) {
+        public void targetFinished(final BuildEvent buildEvent) {
             getLog().debug(buildEvent.getMessage());
         }
 
-        public void taskStarted( final BuildEvent buildEvent ) {
+        public void taskStarted(final BuildEvent buildEvent) {
             getLog().debug(buildEvent.getMessage());
         }
 
-        public void taskFinished( final BuildEvent buildEvent ) {
+        public void taskFinished(final BuildEvent buildEvent) {
             getLog().debug(buildEvent.getMessage());
         }
 
-        public void messageLogged( final BuildEvent buildEvent ) {
+        public void messageLogged(final BuildEvent buildEvent) {
             getLog().debug(buildEvent.getMessage());
         }
     }


### PR DESCRIPTION
Hi George,

I found out why this plugin is failing to build with my new  changes to intellij-sonar-plugin.
Also I can easily reproduce the issue also with the existing intellij-sonar-plugin project (without my changes).

Currently in our pom.xml (intelliJ-plugin) we use compile scope for 'forms_rt', but in fact is not needed to be part of the deployment nor compile scope because comes with IntelliJ.

<dependency>
            <groupId>com.intellij</groupId>
            <artifactId>forms_rt</artifactId>
            <version>${idea.version}</version>
            <scope>compile</scope>
        </dependency>

 However if we put to 'provided' scope the ideauidesigner-maven-plugin will crash with some class not found exception which is in this jar.

What I did is I tweaked the class path building for ant. Every class path element must be included even the 'provided' ones (sure excluding the test scope ones).

My latest push to 'intellij-sonar-plugin' is failing because would require to change the scope for opeanapi.jar and idea-utils.jar from provided to compile. But having this fix is not require anymore.

I had to bump the jar version to grab every project dependency not just the 'compile' scope.

What do you think?
