### PR TITLE
Fixed bug where artifacts with test scope would still be added to the classpath

### DIFF
--- a/src/main/java/org/codehaus/mojo/ideauidesigner/Javac2Mojo.java
+++ b/src/main/java/org/codehaus/mojo/ideauidesigner/Javac2Mojo.java
@@ -146,7 +146,7 @@ public class Javac2Mojo
 
         for (Iterator iterator = artifacts.iterator(); iterator.hasNext();) {
             final Artifact artifact = (Artifact) iterator.next();
-            if ( ! "jar".equals( artifact.getType() ) || Artifact.SCOPE_TEST.equals(artifact.getType()))
+            if ( ! "jar".equals( artifact.getType() ) || Artifact.SCOPE_TEST.equals(artifact.getScope()))
               continue;
 
             classpath.createPathElement().setLocation( artifact.getFile() );


### PR DESCRIPTION
Fixed bug where artifacts with test scope would still be added to the classpath.
This would cause a null pointer if there was a transitive dependence on an artifact with test scope 
